### PR TITLE
Version 2.0.1

### DIFF
--- a/examples/Example17_Parser/Example17_Parser.ino
+++ b/examples/Example17_Parser/Example17_Parser.ino
@@ -86,9 +86,9 @@ void setup()
     Serial.println("UM980 detected!");
 
     // Enable low level debugging for the parser in the Unicore GNSS library
-//    myGNSS.enableParserDebug();
-//    myGNSS.enableParserErrors();
-//    myGNSS.printParserConfiguration();
+//    myGNSS.enableParserDebug(output);
+//    myGNSS.enableParserErrors(output);
+//    myGNSS.printParserConfiguration(output);
 
     // Clear saved configurations, satellite ephemerides, position information, and reset baud rate to 115200bps.
     resetUM980();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun UM980 Triband RTK GNSS Arduino Library
-version=2.0.0
+version=2.0.1
 author=SparkFun Electronics
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for Serial Communication and Configuration of the UM980

--- a/src/SparkFun_Unicore_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_Unicore_GNSS_Arduino_Library.cpp
@@ -1318,36 +1318,55 @@ void UM980::unicoreHandler(uint8_t *response, uint16_t length)
         // Is this a NMEA sentence?
         if (response[0] == '$')
         {
-            response[length] = '\0'; // Force terminator because strncasestr does not exist
-
-            // The UM980 does not respond to binary requests when there is no GNSS reception.
-            // Block BestNavB, etc commands if there is no fix.
-            // Look for GNGGA NMEA then extract GNSS position status (spot 6).
-            // $GNGGA,181535.00,,,,,0,00,9999.0,,,,,,*43
-            char *responsePointer = strcasestr((char *)response, "GNGGA");
-            if (responsePointer != nullptr) // Found
+            // Use a do-while(0) so we can break
+            do
             {
-                char gngga[100];
-                strncpy(gngga, (const char *)response, length - 1); // Make copy before strtok
+                const uint16_t maxLength = 120;
+                char gngga[maxLength + 1];
 
-                debugPrintf("Unicore Lib: GNGGA message: %s\r\n", gngga);
-
-                char *pt;
-                pt = strtok(gngga, ",");
-                int counter = 0;
-                while (pt != NULL)
+                if (length > maxLength)
                 {
-                    int spotValue = atoi(pt);
-                    if (counter++ == 6)
-                        nmeaPositionStatus = spotValue;
-                    pt = strtok(NULL, ",");
+                    debugPrintf("Unicore Lib: NMEA message too long: %d\r\n", length);
+                    break;
                 }
-            }
-            else
-            {
-                // Unhandled NMEA message
-                // debugPrintf("Unicore Lib: Unhandled NMEA sentence (%d bytes): %s\r\n", length, (char *)response);
-            }
+
+                strncpy(gngga, (const char *)response, length); // Make copy before strtok
+                gngga[length] = '\0'; // Force terminator because strncasestr does not exist
+
+                // The UM980 does not respond to binary requests when there is no GNSS reception.
+                // Block BestNavB, etc commands if there is no fix.
+                // Look for GNGGA NMEA then extract GNSS position status (spot 6).
+                // $GNGGA,181535.00,,,,,0,00,9999.0,,,,,,*43
+                char *responsePointer = strcasestr((char *)gngga, "GNGGA");
+                if (responsePointer != nullptr) // Found
+                {
+                    debugPrintf("Unicore Lib: GNGGA message: %s\r\n", gngga);
+
+                    // A health warning about strtok:
+                    // strtok will convert any delimiters it finds ("," in our case) into NULL characters.
+                    // Also, be very careful that you do not use strtok within an strtok while loop.
+                    // The next call of strtok(NULL, ...) in the outer loop will use the pointer saved from the inner loop!
+                    // The same is true for tasks!
+                    // The solution is to use strtok_r - the reentrant version of strtok
+
+                    char *preservedPointer;
+                    char *pt;
+                    pt = strtok_r(gngga, ",", &preservedPointer); // This will blow the , away
+                    int counter = 0;
+                    while ((pt != NULL) && (counter <= 6)) // Stop after spot 6
+                    {
+                        int spotValue = atoi(pt);
+                        if (counter++ == 6) // If this is spot 6, save value into status. Post-increment counter
+                            nmeaPositionStatus = spotValue;
+                        pt = strtok_r(NULL, ",", &preservedPointer); // This will blow the , away
+                    }
+                }
+                else
+                {
+                    // Unhandled NMEA message
+                    // debugPrintf("Unicore Lib: Unhandled NMEA sentence (%d bytes): %s\r\n", length, (char *)response);
+                }
+            } while (0);
         }
         else
         {


### PR DESCRIPTION
This release:
* Prevents stack smashing seen in RTK Everywhere on ESP32
    * It's not clear if the out-of-bounds ```response[length] = '\0';``` was causing this, but it seems likely. The smashed stack was seen when returning from ```unicoreHandler```
    * Replaces ```strtok``` with ```strtok_r```
* Updates Example17 to show how to call the SEMP debug functions