### PR TITLE
v2.0.2 - add support for CONFIG BASEANTENNAMODEL

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -120,5 +120,11 @@ make clean
 make
 make clean
 
+# User_Parser_Test
+cd ../Example22_SetAntennaDescription
+make clean
+make
+make clean
+
 # Return to origin directory
 cd ../..

--- a/examples/Example18_CheckConfig/Example18_CheckConfig.ino
+++ b/examples/Example18_CheckConfig/Example18_CheckConfig.ino
@@ -27,6 +27,7 @@
   $CONFIG,COM1,CONFIG COM1 115200*23
   $CONFIG,COM2,CONFIG COM2 115200*23
   $CONFIG,COM3,CONFIG COM3 115200*23
+  $CONFIG,BASEANTENNAMODEL,CONFIG BASEANTENNAMODEL "ADVNULLANTENNA NULL" "1234" 123 NO*1D
 
   These examples are targeted for an ESP32 platform but any platform that has multiple
   serial UARTs should be compatible.

--- a/examples/Example22_SetAntennaDescription/Example22_SetAntennaDescription.ino
+++ b/examples/Example22_SetAntennaDescription/Example22_SetAntennaDescription.ino
@@ -1,0 +1,222 @@
+/*
+  Set RTCM 1033 Antenna Description
+  By: Paul Clark
+  SparkFun Electronics
+  Date: August 12th, 2026
+  License: MIT. Please see LICENSE.md for more information.
+
+  When operating as a Base, the UM980 can generate RTCM 1033 messages which contain
+  the Antenna Description. These default to:
+  Antenna description: ADVNULLANTENNA
+  Antenna serial number: a0001
+  Antenna Setup ID: 0
+
+  This example shows how to change the antenna description.
+
+  These examples are targeted for an ESP32 platform but any platform that has multiple
+  serial UARTs should be compatible.
+
+  Feel like supporting open source hardware?
+  Buy a board from SparkFun!
+  SparkFun Triband GNSS RTK Breakout - UM980 (GPS-23286) https://www.sparkfun.com/products/23286
+
+  Hardware Connections:
+  Connect RX2 (green wire) of the UM980 to pin 4 on the ESP32
+  Connect TX2 (orange wire) of the UM980 to pin 13 on the ESP32
+  To make this easier, a 4-pin locking JST cable can be purchased here: https://www.sparkfun.com/products/17240
+  Note: Almost any ESP32 pins can be used for serial.
+  Connect a dual or triband GNSS antenna: https://www.sparkfun.com/products/21801
+
+*/
+
+int pin_UART1_TX = 17; // ESP32 Thing Plus C
+int pin_UART1_RX = 16;
+
+#include <SparkFun_Unicore_GNSS_Arduino_Library.h> //http://librarymanager/All#SparkFun_Unicore_GNSS
+
+UM980 myGNSS;
+
+HardwareSerial SerialGNSS(1); //Use UART1 on the ESP32
+
+unsigned long lastCheck = 0;
+
+unsigned long startTime = 0;
+unsigned long convergingStartTime = 0;
+unsigned long timeToConvergence = 0;
+
+// Custom Antenna Description
+//const char antennaDescription[] = "CONFIG BASEANTENNAMODEL \"ADVNULLANTENNA\" \"Unknown\" 123 NO";
+// Response is:
+// $command,CONFIG BASEANTENNAMODEL "ADVNULLANTENNA" "Unknown" 123 NO,response: OK*1F\r\n
+
+
+// GNSS Defaults
+const char antennaDescription[] = "CONFIG BASEANTENNAMODEL \"ADVNULLANTENNA\" \"a0001\" 0 NO";
+// Response is:
+// $command,CONFIG BASEANTENNAMODEL "ADVNULLANTENNA" "a0001" 0 NO,response: OK*37\r\n
+
+
+// Longest possible configuration. Description and serial number can be up to 31 chars
+//const char antennaDescription[] = "CONFIG BASEANTENNAMODEL 0123456789012345678901234567890 0123456789012345678901234567890 123 USER";
+// Response is:
+// $command,CONFIG BASEANTENNAMODEL 0123456789012345678901234567890 0123456789012345678901234567890 123 USER,response: OK*50\r\n
+
+// If the description or serial number contain spaces, they need to be included in quotes
+// BUT the quotes are then included in the UM980's 31 character length check!
+// Also, if we send "01234567890123456789012345678" the CONFIG response only contains "01234567890123456789012345678
+// The trailing quote gets dropped... (This is with firmware 17548)
+// So, this is the longest antenna description we can send which includes quotes:
+//const char antennaDescription[] = "CONFIG BASEANTENNAMODEL \"0123456789012345678901234567\" \"0123456789012345678901234567\" 123 USER";
+// Response is:
+// $command,CONFIG BASEANTENNAMODEL "0123456789012345678901234567" "0123456789012345678901234567" 123 USER,response: OK*50\r\n
+
+
+void setup()
+{
+  Serial.begin(115200);
+  delay(250);
+  Serial.println();
+  Serial.println("SparkFun UM980 Example 22");
+
+  //The CONFIG response can be ~500 bytes over runing the ESP32 RX buffer of 256 bytes
+  //Increase the size of the RX buffer
+  SerialGNSS.setRxBufferSize(1024);
+
+  //We must start the serial port before using it in the library
+  SerialGNSS.begin(115200, SERIAL_8N1, pin_UART1_RX, pin_UART1_TX);
+
+  //myGNSS.enableDebugging(); // Print all debug to Serial
+
+  if (myGNSS.begin(SerialGNSS, "SFE_Unicore_GNSS_Library", output) == false) //Give the serial port over to the library
+  {
+    Serial.println("UM980 failed to respond. Check ports and baud rates. Freezing...");
+    while (true);
+  }
+  Serial.println("UM980 detected!");
+
+  int um980Version = String(myGNSS.getVersion()).toInt(); //Convert the string response to a value
+
+  Serial.print("UM980 firmware version: v");
+  Serial.println(um980Version);
+
+  if (myGNSS.isConfigurationPresent("CONFIG BASEANTENNAMODEL") == true)
+    Serial.println("BASEANTENNAMODEL has been set previously");
+
+  //myGNSS.enablePrintParserTransitions();
+  //myGNSS.enablePrintRxMessages();
+  //myGNSS.enableRxMessageDump();
+  //myGNSS.enablePrintBadChecksums();
+
+  if (myGNSS.isConfigurationPresent(antennaDescription) == true)
+    Serial.println("BASEANTENNAMODEL already configured");
+
+  while (myGNSS.sendCommand(antennaDescription) == false)
+    Serial.println("BASEANTENNAMODEL error. Retrying...");
+
+  Serial.println("BASEANTENNAMODEL configured");
+
+  //myGNSS.disablePrintBadChecksums();
+  //myGNSS.disableRxMessageDump();
+  //myGNSS.disablePrintRxMessages();
+  //myGNSS.disablePrintParserTransitions();
+
+  startTime = millis();
+
+  Serial.println("r) Reset ESP");
+  Serial.println("R) Factory reset UM980");
+}
+
+void loop()
+{
+  if (Serial.available())
+  {
+    byte incoming = Serial.read();
+    if (incoming == 'r')
+      ESP.restart();
+    else if (incoming == 'R')
+      um980Reset();
+  }
+
+
+  myGNSS.update(); //Regularly call to parse any new data
+
+  if (millis() - lastCheck > 1000)
+  {
+    lastCheck = millis();
+    printUpdate();
+  }
+}
+
+void printUpdate()
+{
+  Serial.print("Lat/Long/Alt: ");
+  Serial.print(myGNSS.getLatitude(), 11); //Accurate 11 decimal places
+  Serial.print("/");
+  Serial.print(myGNSS.getLongitude(), 11);
+  Serial.print("/");
+  Serial.print(myGNSS.getAltitude(), 4); //Accurate to 4 decimal places
+  Serial.println();
+
+  Serial.print("Deviation of Lat/Long/Alt (m): ");
+  Serial.print(myGNSS.getLatitudeDeviation(), 4);
+  Serial.print("/");
+  Serial.print(myGNSS.getLongitudeDeviation(), 4);
+  Serial.print("/");
+  Serial.println(myGNSS.getAltitudeDeviation(), 4);
+
+  Serial.print("Satellites in view: ");
+  Serial.print(myGNSS.getSIV());
+  Serial.println();
+
+  Serial.println();
+}
+
+void um980Reset()
+{
+  while (Serial.available()) Serial.read(); //Clear RX buffer
+  Serial.println("Press any key to factory reset the UM980");
+  while (Serial.available() == 0) delay(1); //Wait for user to press a button
+
+  // Clear saved configurations, satellite ephemerides, position information, and reset baud rate to 115200bps.
+  if (myGNSS.factoryReset() == true)
+    Serial.println("UM980 now reset to factory defaults");
+  else
+    Serial.println("Error resetting UM980 to factory defaults");
+
+  Serial.println("Waiting for UM980 to reboot");
+
+  while (1)
+  {
+    delay(1000); //Wait for device to reboot
+    if (myGNSS.isConnected() == true) break;
+    else Serial.println("Device still rebooting");
+  }
+
+  Serial.println("UM980 has completed reset");
+}
+
+//----------------------------------------
+// Output a buffer of data
+//
+// Inputs:
+//   buffer: Address of a buffer of data to output
+//   length: Number of bytes of data to output
+//----------------------------------------
+void output(uint8_t * buffer, size_t length)
+{
+    size_t bytesWritten;
+
+    if (Serial)
+    {
+        while (length)
+        {
+            // Wait until space is available in the FIFO
+            while (Serial.availableForWrite() == 0);
+
+            // Output the character
+            bytesWritten = Serial.write(buffer, length);
+            buffer += bytesWritten;
+            length -= bytesWritten;
+        }
+    }
+}

--- a/examples/Example22_SetAntennaDescription/makefile
+++ b/examples/Example22_SetAntennaDescription/makefile
@@ -1,0 +1,209 @@
+######################################################################
+# makefile
+#
+# Builds the example
+######################################################################
+
+.ONESHELL:
+SHELL=/bin/bash
+
+##########
+# Source files
+##########
+
+SKETCH=Example22_SetAntennaDescription
+
+DEPENDS_ON_FILES += makefile
+DEPENDS_ON_FILES += *.ino
+
+PARTITION_CSV_FILE=RTKEverywhere
+BOOT_LOADER_BIN=RTK_Surveyor.ino.bootloader.bin
+PARTITION_BIN=RTK_Everywhere_Partitions_8MB.bin
+BOOT_APP0_BIN=boot_app0.bin
+
+ifeq ($(OS),Windows_NT)
+# Windows NT utilities
+CLEAR=cls
+DELETE=del /s
+TERMINAL_APP=
+TERMINAL_PORT=
+TERMINAL_PARAMS=
+
+# Windows NT generic paths
+USER_DIRECTORY_PATH=C:\Users\$(USERNAME)\
+
+# Windows build support
+BUILD_PATH=build\esp32.esp32.esp32\
+ARDUINO_LIBRARY_PATH=$(USER_DIRECTORY_PATH)Documents\Arduino\libraries
+HOME_BOARD_PATH=$(USER_DIRECTORY_PATH)AppData\Local\Arduino15\packages\esp32
+
+# Windows upload support
+ESPTOOL_PATH=$(USER_DIRECTORY_PATH)Arduino\hardware\espressif\esp32\tools\esptool\
+BOOT_LOADER_PATH=$(USER_DIRECTORY_PATH)SparkFun\SparkFun_RTK_Firmware_Uploader\RTK_Firmware_Uploader\resource\
+
+else
+# Linux utilities
+CLEAR=clear
+DELETE=rm -Rf
+TERMINAL_APP=minicom
+TERMINAL_PARAMS=-b 115200 -8 < /dev/tty
+
+# Linux generic paths
+USER_DIRECTORY_PATH=~/
+ARDUINO_LIBRARY_PATH=$(USER_DIRECTORY_PATH)Arduino/libraries
+HOME_BOARD_PATH=$(USER_DIRECTORY_PATH).arduino15/packages/esp32
+
+# Linux build  support
+BUILD_PATH=build/esp32.esp32.esp32/
+
+# Linux upload support
+ESPTOOL_PATH=~/Arduino/hardware/espressif/esp32/tools/esptool/
+BOOT_LOADER_PATH=~/SparkFun/SparkFun_RTK_Firmware_Uploader/RTK_Firmware_Uploader/resource/
+
+endif
+
+##########
+# Buid all the sources - must be first
+##########
+
+EXAMPLE += $(BUILD_PATH)$(SKETCH).ino.bin
+
+.PHONY: all
+
+all: $(EXAMPLE)
+
+##########
+# Buid firmware
+##########
+
+DEFINES=
+
+DEBUG_LEVEL=none
+#DEBUG_LEVEL=error
+#DEBUG_LEVEL=warn
+#DEBUG_LEVEL=info
+#DEBUG_LEVEL=debug
+#DEBUG_LEVEL=verbose
+
+$(BUILD_PATH)$(SKETCH).ino.bin:	$(SKETCH).ino   $(DEPENDS_ON_FILES)
+	$(CLEAR)
+	echo $(SKETCH)
+	echo "Defines: $(DEFINES)"
+	arduino-cli \
+		compile \
+		--fqbn   "esp32:esp32:esp32":DebugLevel=$(DEBUG_LEVEL)   $(SKETCH).ino \
+		--warnings   default \
+		--build-property   build.partitions=$(PARTITION_CSV_FILE) \
+		--build-property   upload.maximum_size=6291456 \
+		--build-property   "compiler.cpp.extra_flags=-MMD   -c   $(DEFINES)" \
+		--export-binaries
+
+##########
+# Terminal
+##########
+
+.PHONY:	terminal
+
+terminal:
+	if   [   -a   "/dev/ttyUSB0"   ];   then
+	    export TERMINAL_PORT=/dev/ttyUSB0
+	else
+	    if   [   -a   "/dev/ttyUSB1"   ];   then
+	        export TERMINAL_PORT=/dev/ttyUSB1
+	    else
+	        if   [   -a   "/dev/ttyUSB2"   ];   then
+	            export TERMINAL_PORT=/dev/ttyUSB2
+	        else
+	            if   [   -a   "/dev/ttyUSB3"   ];   then
+	                export TERMINAL_PORT=/dev/ttyUSB3
+	            else
+	                if   [   -a   "/dev/ttyACM0"   ];   then
+	                    export TERMINAL_PORT=/dev/ttyACM0
+	                else
+	                    if   [   -a   "/dev/ttyACM1"   ];   then
+	                        export TERMINAL_PORT=/dev/ttyACM1
+	                    else
+	                        if   [   -a   "/dev/ttyACM2"   ];   then
+	                            export TERMINAL_PORT=/dev/ttyACM2
+	                        else
+	                            if   [   -a   "/dev/ttyACM3"   ];   then
+	                                export TERMINAL_PORT=/dev/ttyACM3
+	                            fi
+	                        fi
+	                    fi
+	                fi
+	            fi
+	        fi
+	    fi
+	fi
+	echo $$TERMINAL_PORT
+	$(TERMINAL_APP)   -D $$TERMINAL_PORT   $(TERMINAL_PARAMS)
+
+##########
+# Upload the firmware
+##########
+
+.PHONY: upload
+
+upload:	$(BUILD_PATH)$(SKETCH).ino.bin
+	if   [   -a   "/dev/ttyUSB0"   ];   then
+	    export TERMINAL_PORT=/dev/ttyUSB0
+	else
+	    if   [   -a   "/dev/ttyACM0"   ];   then
+	        export TERMINAL_PORT=/dev/ttyACM0
+	    else
+	        if   [   -a   "/dev/ttyUSB1"   ];   then
+	            export TERMINAL_PORT=/dev/ttyUSB1
+	        else
+	            if   [   -a   "/dev/ttyACM1"   ];   then
+	                export TERMINAL_PORT=/dev/ttyACM1
+	            else
+	                if   [   -a   "/dev/ttyUSB2"   ];   then
+	                    export TERMINAL_PORT=/dev/ttyUSB2
+	                else
+	                    if   [   -a   "/dev/ttyACM2"   ];   then
+	                        export TERMINAL_PORT=/dev/ttyACM2
+	                    else
+	                        if   [   -a   "/dev/ttyUSB3"   ];   then
+	                            export TERMINAL_PORT=/dev/ttyUSB3
+	                        else
+	                            if   [   -a   "/dev/ttyACM3"   ];   then
+	                                export TERMINAL_PORT=/dev/ttyACM3
+	                            else
+	                                ls /dev/ttyACM*
+	                                ls /dev/ttyUSB*
+	                                ps -ax | grep bossac
+	                            fi
+	                        fi
+	                    fi
+	                fi
+	            fi
+	        fi
+	    fi
+	fi
+	echo $$TERMINAL_PORT
+	python3 $(ESPTOOL_PATH)esptool.py \
+        --chip   esp32 \
+        --port   $$TERMINAL_PORT \
+        --baud   460800 \
+        --before   default_reset \
+        --after   hard_reset \
+        write_flash \
+        --flash_mode dio \
+        --flash_freq 80m \
+        --flash_size detect \
+        --compress \
+         0x1000   $(BOOT_LOADER_PATH)$(BOOT_LOADER_BIN) \
+         0x8000   $(BOOT_LOADER_PATH)$(PARTITION_BIN) \
+         0xe000   $(BOOT_LOADER_PATH)$(BOOT_APP0_BIN) \
+        0x10000   $<
+	$(TERMINAL_APP)   -D $$TERMINAL_PORT   $(TERMINAL_PARAMS)
+
+########
+# Clean the build directory
+##########
+
+.PHONY: clean
+
+clean:
+	$(DELETE) build

--- a/keywords.txt
+++ b/keywords.txt
@@ -18,8 +18,33 @@ isConnected	KEYWORD2
 isBlocking	KEYWORD2
 enableDebugging	KEYWORD2
 disableDebugging	KEYWORD2
+update	KEYWORD2
+updateOnce	KEYWORD2
+
+enableDebugging	KEYWORD2
+disableDebugging	KEYWORD2
+
+enableParserDebug	KEYWORD2
+disableParserDebug	KEYWORD2
+enableParserErrors	KEYWORD2
+disableParserErrors	KEYWORD2
+
+enableBinaryBeforeFix	KEYWORD2
+disableBinaryBeforeFix	KEYWORD2
+
+enablePrintBadChecksums	KEYWORD2
+disablePrintBadChecksums	KEYWORD2
+enablePrintParserTransitions	KEYWORD2
+disablePrintParserTransitions	KEYWORD2
+enablePrintRxMessages	KEYWORD2
+disablePrintRxMessages	KEYWORD2
+enableRxMessageDump	KEYWORD2
+disableRxMessageDump	KEYWORD2
+
+dumpBuffer	KEYWORD2
 
 setMode	KEYWORD2
+getMode	KEYWORD2
 setModeBase	KEYWORD2
 setModeBaseGeodetic	KEYWORD2
 setModeBaseECEF	KEYWORD2
@@ -29,30 +54,31 @@ setModeRoverSurvey	KEYWORD2
 setModeRoverUAV	KEYWORD2
 setModeRoverAutomotive	KEYWORD2
 setModeRoverMow	KEYWORD2
-setPortBaudrate	KEYWORD2
-setBaudrate	KEYWORD2
 
+setPortBaudrate	KEYWORD2
+getPortBaudrate	KEYWORD2
+setBaudrate	KEYWORD2
 enablePPS	KEYWORD2
 disablePPS	KEYWORD2
 configurePPS	KEYWORD2
 
 enableConstellation	KEYWORD2
 disableConstellation	KEYWORD2
-
 setElevationAngle	KEYWORD2
+getElevationAngle	KEYWORD2
 setMinCNO	KEYWORD2
-
 enableFrequency	KEYWORD2
 disableFrequency	KEYWORD2
 enableSystem	KEYWORD2
 disableSystem	KEYWORD2
+
 setNMEAPortMessage	KEYWORD2
 setNMEAMessage	KEYWORD2
 setRTCMPortMessage	KEYWORD2
 setRTCMMessage	KEYWORD2
+
 disableOutput	KEYWORD2
 disableOutputPort	KEYWORD2
-
 factoryReset	KEYWORD2
 reset	KEYWORD2
 saveConfiguration	KEYWORD2
@@ -60,7 +86,6 @@ saveConfiguration	KEYWORD2
 serialAvailable	KEYWORD2
 serialRead	KEYWORD2
 serialPrintln	KEYWORD2
-
 clearBuffer	KEYWORD2
 
 sendCommand	KEYWORD2
@@ -77,23 +102,35 @@ checkCRC	KEYWORD2
 getLatitude	KEYWORD2
 getLongitude	KEYWORD2
 getAltitude	KEYWORD2
+getHorizontalSpeed	KEYWORD2
+getVerticalSpeed	KEYWORD2
+getTrackGround	KEYWORD2
+
 getLatitudeDeviation	KEYWORD2
 getLongitudeDeviation	KEYWORD2
 getAltitudeDeviation	KEYWORD2
+getHorizontalSpeedDeviation	KEYWORD2
+getVerticalSpeedDeviation	KEYWORD2
+
 getEcefX	KEYWORD2
 getEcefY	KEYWORD2
 getEcefZ	KEYWORD2
 getEcefXDeviation	KEYWORD2
 getEcefYDeviation	KEYWORD2
 getEcefZDeviation	KEYWORD2
+
 getGeoidalSeparation	KEYWORD2
+
 getSIV	KEYWORD2
 getSatellitesUsed	KEYWORD2
 getSatellitesTracked	KEYWORD2
 getSolutionStatus	KEYWORD2
 getPositionType	KEYWORD2
+getVelocityType	KEYWORD2
+
 getRTKSolution	KEYWORD2
 getPseudorangeCorrection	KEYWORD2
+
 getYear	KEYWORD2
 getMonth	KEYWORD2
 getDay	KEYWORD2
@@ -105,15 +142,14 @@ getTimeStatus	KEYWORD2
 getDateStatus	KEYWORD2
 getTimeOffset	KEYWORD2
 getTimeOffsetDeviation	KEYWORD2
+
 getFixAgeMilliseconds	KEYWORD2
-getModuleType	KEYWORD2
+
+getModelType	KEYWORD2
 getID	KEYWORD2
 getVersion	KEYWORD2
 getCompileTime	KEYWORD2
 getVersionFull	KEYWORD2
-
-enableBinaryBeforeFix	KEYWORD2
-disableBinaryBeforeFix	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun UM980 Triband RTK GNSS Arduino Library
-version=2.0.1
+version=2.0.2
 author=SparkFun Electronics
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for Serial Communication and Configuration of the UM980

--- a/src/SparkFun_Unicore_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_Unicore_GNSS_Arduino_Library.cpp
@@ -140,7 +140,11 @@ bool UM980::begin(HardwareSerial &serialPort,
 {
     ptrUM980 = this;
     _hwSerialPort = &serialPort;
-    _debugPort = parserDebug;
+
+    if (!((parserDebug == nullptr) && (_debugPort != nullptr)))
+        // If _debugPort has been configured by enableDebugging
+        // don't overwrite it with nullptr
+        _debugPort = parserDebug;
 
     // Initialize the parser
     size_t bufferLength = sempGetBufferLength(unicoreParserTable, unicoreParserCount, BUFFER_LENGTH);
@@ -219,6 +223,12 @@ bool UM980::update()
 void UM980::enablePrintParserTransitions()
 {
     _printParserTransitions = true;
+}
+
+// Disable the display of parser transitions
+void UM980::disablePrintParserTransitions()
+{
+    _printParserTransitions = false;
 }
 
 // Checks for new data once
@@ -1967,6 +1977,7 @@ void UM980::configHandler(uint8_t *response, uint16_t length)
 // $CONFIG,COM1,CONFIG COM1 115200*23
 // $CONFIG,COM2,CONFIG COM2 115200*23
 // $CONFIG,COM3,CONFIG COM3 115200*23
+// $CONFIG,BASEANTENNAMODEL,CONFIG BASEANTENNAMODEL "ADVNULLANTENNA NULL" "1234" 123 NO*1D
 bool UM980::isConfigurationPresent(const char *stringToFind, uint16_t maxWaitMs)
 {
     Um980Result result;

--- a/src/SparkFun_Unicore_GNSS_Arduino_Library.h
+++ b/src/SparkFun_Unicore_GNSS_Arduino_Library.h
@@ -227,7 +227,8 @@ class UM980
 
     void dumpBuffer(const uint8_t *buffer, uint16_t length);
 
-    char commandName[50] = ""; // Passes the command type into parser - CONFIG PPS ENABLE GPS POSITIVE 200000 1000 0 0
+    // CONFIG BASEANTENNAMODEL 0123456789012345678901234567890 0123456789012345678901234567890 123 USER
+    char commandName[100] = ""; // Passes the command type into parser
     uint8_t commandResponse = UM980_RESULT_OK; // Gets EOM result from parser
 
     // Mode


### PR DESCRIPTION
This release:
* Adds support for the RTCM 1033 Antenna Description through CONFIG BASEANTENNAMODEL
    * Please see the new Example22_SetAntennaDescription for details
* Missing KEYWORD2 have been added to keywords.txt
* The missing method ```disablePrintParserTransitions()``` has been added
* ```begin``` no longer overwrites ```_debugPort``` with ```nullptr``` if it has been set by ```enableDebugging()``` before ```begin``` is called
* The internal buffer ```commandName``` has been increased to 100 characters - to be able to hold the longest possible CONFIG BASEANTENNAMODEL command